### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
   before_action :set_item, only: [:edit, :update, :show, :destroy]
   def index
-    @items = Item.all
+    @items = Item.all.order(id: :desc)
   end
 
   def show

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -32,7 +32,7 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Create different versions of your uploaded files:
   # version :thumb do
-  process resize_to_fit: [100, 100]
+  process resize_to_fit: [1000, 1000]
   # end
 
   # Add a white list of extensions which are allowed to be uploaded.

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -115,7 +115,7 @@
             %h3.Container__head 新規投稿商品
             .Container__lists
               .Container__lists__show
-              - @items.last(4).each do |item|
+              - @items.first(4).each do |item|
                 = link_to item_path(item.id), class: "Picup-item" do
                   = image_tag item.item_images[0].image.to_s
                   .Picup-item__body


### PR DESCRIPTION
#What 
商品詳細表示機能の実装

・商品出品時に登録した情報が見られるようになっている
・ログアウト状態でも商品詳細ページを見ることができる
・出品者にしか商品の情報編集・削除のリンクが踏めないようになっている
・出品者以外にしか商品購入のリンクが踏めないようになっている

#Why
出品者と購入者の差別化、ログインユーザとログインしていないユーザーの差別化をはかるため。

![商品詳細表示](https://user-images.githubusercontent.com/67101070/89395472-5280a080-d748-11ea-9b7d-f41321699f9c.gif)
